### PR TITLE
finish test item error case

### DIFF
--- a/lib/report-portal-client.js
+++ b/lib/report-portal-client.js
@@ -366,8 +366,24 @@ class RPClient {
                     })
             }, (error) => {
                 this.cleanMap(itemObj.childrens);
-                this.debug && console.log(`Error finish test item ${itemTempId}`);
-                itemObj.rejectFinish(error);
+                this.debug && console.log(`Error finish children of test item ${itemTempId}`);
+                this.debug && console.log(`Finish test item ${itemTempId}`);
+                itemObj.promiseStart
+                    .then( () => {
+                        let url = [this.baseURL, "item", itemObj.realId].join("/");
+                        this.debug && console.log(`Finish test item ${itemTempId}`);
+                        helpers.getServerResult(url, finishTestItemData, {headers: this.headers}, "PUT")
+                            .then((responce) => {
+                                this.debug && console.log(`Success finish item ${itemTempId}`);
+                                itemObj.resolveFinish(responce);
+                            }, (error) => {
+                                this.debug && console.log(`Error finish test item ${itemTempId}: ` );
+                                console.dir(error);
+                                itemObj.rejectFinish(error);
+                            })
+                    }, (error) => {
+                        itemObj.rejectFinish(error);
+                    })
             });
 
         return {

--- a/lib/report-portal-client.js
+++ b/lib/report-portal-client.js
@@ -348,42 +348,12 @@ class RPClient {
         Promise.all( itemObj.childrens.map((itemId) => { return this.map[itemId].promiseFinish; }) )
             .then(() => {
                 this.cleanMap(itemObj.childrens);
-                itemObj.promiseStart
-                    .then( () => {
-                        let url = [this.baseURL, "item", itemObj.realId].join("/");
-                        this.debug && console.log(`Finish test item ${itemTempId}`);
-                        helpers.getServerResult(url, finishTestItemData, {headers: this.headers}, "PUT")
-                            .then((responce) => {
-                                this.debug && console.log(`Success finish item ${itemTempId}`);
-                                itemObj.resolveFinish(responce);
-                            }, (error) => {
-                                this.debug && console.log(`Error finish test item ${itemTempId}: ` );
-                                console.dir(error);
-                                itemObj.rejectFinish(error);
-                            })
-                    }, (error) => {
-                        itemObj.rejectFinish(error);
-                    })
+                this.finishTestItemPromiseStart(itemObj, itemTempId, finishTestItemData);
             }, (error) => {
                 this.cleanMap(itemObj.childrens);
                 this.debug && console.log(`Error finish children of test item ${itemTempId}`);
                 this.debug && console.log(`Finish test item ${itemTempId}`);
-                itemObj.promiseStart
-                    .then( () => {
-                        let url = [this.baseURL, "item", itemObj.realId].join("/");
-                        this.debug && console.log(`Finish test item ${itemTempId}`);
-                        helpers.getServerResult(url, finishTestItemData, {headers: this.headers}, "PUT")
-                            .then((responce) => {
-                                this.debug && console.log(`Success finish item ${itemTempId}`);
-                                itemObj.resolveFinish(responce);
-                            }, (error) => {
-                                this.debug && console.log(`Error finish test item ${itemTempId}: ` );
-                                console.dir(error);
-                                itemObj.rejectFinish(error);
-                            })
-                    }, (error) => {
-                        itemObj.rejectFinish(error);
-                    })
+                this.finishTestItemPromiseStart(itemObj, itemTempId, finishTestItemData);
             });
 
         return {
@@ -391,6 +361,9 @@ class RPClient {
             promise: itemObj.promiseFinish
         };
     }
+
+
+
     saveLog(itemObj, requestPromiseFunc) {
         const tempId = this.getUniqId();
         this.map[tempId] = this.getNewItemObj((resolve, reject) => {
@@ -526,6 +499,27 @@ class RPClient {
         ];
         return Buffer.concat(buffers);
     }
+
+
+    finishTestItemPromiseStart(itemObj, itemTempId, finishTestItemData) {
+        itemObj.promiseStart
+            .then( () => {
+                let url = [this.baseURL, "item", itemObj.realId].join("/");
+                this.debug && console.log(`Finish test item ${itemTempId}`);
+                helpers.getServerResult(url, finishTestItemData, {headers: this.headers}, "PUT")
+                    .then((responce) => {
+                        this.debug && console.log(`Success finish item ${itemTempId}`);
+                        itemObj.resolveFinish(responce);
+                    }, (error) => {
+                        this.debug && console.log(`Error finish test item ${itemTempId}: ` );
+                        console.dir(error);
+                        itemObj.rejectFinish(error);
+                    })
+            }, (error) => {
+                itemObj.rejectFinish(error);
+            })
+    }
+
 
 }
 


### PR DESCRIPTION
https://github.com/reportportal/client-javascript/issues/18

finish test item even if its children fail, this prevents step from
hanging in progress status and not being closed. 
when sendLog fails for some reason, this results for promise.all 
in finishTestItem
reject with the reason of the first children promise that rejects