### PR TITLE
Update lib/report-portal-client.js

### DIFF
--- a/lib/report-portal-client.js
+++ b/lib/report-portal-client.js
@@ -138,7 +138,7 @@ class RPClient {
                         resolve(response);
                     }, (error) => {
                         console.dir(error);
-                        reject();
+                        reject(error);
                     });
             });
         }


### PR DESCRIPTION
Add error passing to reject in startLaunch. If it hasn't passed, agent-js-jasmine can't get error. For the [issue](https://github.com/reportportal/agent-js-jasmine)