### PR TITLE
feature: add support for custom headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ token     | user's token Report Portal from which you want to send requests. It 
 endpoint  | URL of your server. For example, if you visit the page at 'https://server:8080/ui', then endpoint will be equal to 'https://server:8080/api/v1'.
 launch    | Name of launch at creation.
 project   | The name of the project in which the launches will be created.
+headers   | The object with custom headers for internal http client
 
 ## Api
 Each method (except checkConnect) returns an object in a specific format:

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ token     | user's token Report Portal from which you want to send requests. It 
 endpoint  | URL of your server. For example, if you visit the page at 'https://server:8080/ui', then endpoint will be equal to 'https://server:8080/api/v1'.
 launch    | Name of launch at creation.
 project   | The name of the project in which the launches will be created.
-headers   | The object with custom headers for internal http client
+headers   | (optional) The object with custom headers for internal http client
 
 ## Api
 Each method (except checkConnect) returns an object in a specific format:

--- a/lib/report-portal-client.js
+++ b/lib/report-portal-client.js
@@ -24,16 +24,14 @@ class RPClient {
         this.isLaunchMergeRequired = params.isLaunchMergeRequired === undefined ? false : params.isLaunchMergeRequired;
         this.map = {};
         this.baseURL = [params.endpoint, params.project].join('/');
-        this.options = {
-            headers: {
-                'User-Agent': 'NodeJS',
-                Authorization: `bearer ${params.token}`,
-                ...(params.headers || {}),
-            },
-        };
-        this.headers = {
+        const headers = {
             'User-Agent': 'NodeJS',
             Authorization: `bearer ${params.token}`,
+            ...(params.headers || {}),
+        };
+        this.headers = headers;
+        this.options = {
+            headers,
         };
         this.token = params.token;
         this.config = params;

--- a/lib/report-portal-client.js
+++ b/lib/report-portal-client.js
@@ -28,6 +28,7 @@ class RPClient {
             headers: {
                 'User-Agent': 'NodeJS',
                 Authorization: `bearer ${params.token}`,
+                ...(params.headers || {}),
             },
         };
         this.headers = {
@@ -590,7 +591,7 @@ class RPClient {
             this.buildMultiPartStream([saveLogRQ], fileObj, MULTIPART_BOUNDARY),
             {
                 headers: {
-                    Authorization: `bearer ${this.token}`,
+                    ...this.headers,
                     'Content-Type': `multipart/form-data; boundary=${MULTIPART_BOUNDARY}`,
                 },
             },


### PR DESCRIPTION
It is not possible to attach custom headers (such as when accessing behind cloudflare).
This adds support for such a use-case.

This is backport for https://github.com/BorisOsipov/reportportal-js-client/pull/13