### PR TITLE
allow using custom client config in checkConnection() method

### DIFF
--- a/lib/report-portal-client.js
+++ b/lib/report-portal-client.js
@@ -130,7 +130,7 @@ class RPClient {
 
   checkConnect() {
     const url = [this.config.endpoint.replace('/v2', '/v1'), 'user'].join('/');
-    return RestClient.request('GET', url, {}, { headers: this.headers });
+    return RestClient.request('GET', url, {}, { headers: this.headers, ...this.restClient.getRestConfig()});
   }
 
   async triggerStatisticsEvent() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@reportportal/client-javascript",
-      "version": "5.1.2",
+      "version": "5.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.6.8",

--- a/spec/report-portal-client.spec.js
+++ b/spec/report-portal-client.spec.js
@@ -136,6 +136,30 @@ describe('ReportPortal javascript client', () => {
 
       return expectAsync(request).toBeResolved();
     });
+
+    it('client should include restClientConfig', () => {
+      const client = new RPClient({
+        apiKey: 'test',
+        project: 'test',
+        endpoint: 'https://abc.com/v1',
+        restClientConfig: {
+          proxy: false,
+          timeout: 0,
+        }
+      });
+      spyOn(RestClient, 'request');
+
+      client.checkConnect();
+
+      expect(RestClient.request).toHaveBeenCalledWith('GET','https://abc.com/v1/user', {}, {
+         headers: {
+        'User-Agent': 'NodeJS',
+         Authorization: `bearer test`,
+        },
+        proxy: false,
+        timeout: 0,
+      });
+    });
   });
 
   describe('triggerAnalyticsEvent', () => {


### PR DESCRIPTION
I found the client will throw error of "400 BAD request" when running behind the proxy.
based on this article: https://stackoverflow.com/questions/60578209/axios-proxy-configuration-causing-bad-request
In order to make the client working behind the proxy, I found I need to add some custom parameters in the RPClient,

```
const { HttpsProxyAgent } = require('https-proxy-agent');

const agent = new HttpsProxyAgent('http://proxy_url:port');

const rpClient = new RPClient({
    apiKey: 'reportportalApiKey',
    endpoint: 'http://your-instance.com:8080/api/v1',
    launch: 'LAUNCH_NAME',
    project: 'PROJECT_NAME',
    restClientConfig: {
          proxy: false,
          httpsAgent: proxy,
    }
});
```

I found the solution will work in the startLaunch() method, but not checkConnection(), then I need to realize we need to pass the restClientConfig object to checkConnection() as well, after this fix, then we can use the client work under the corporate proxy using the above code snippet.