### PR TITLE
fixed issue in request method in case if this.restClientConfig is not provided in config

### DIFF
--- a/lib/rest.js
+++ b/lib/rest.js
@@ -67,7 +67,8 @@ class RestClient {
     // Only apply proxy agents if custom agents are not explicitly provided
     // Priority: explicit httpsAgent/httpAgent > proxy config > default
     const hasCustomAgents =
-      'httpsAgent' in this.restClientConfig || 'httpAgent' in this.restClientConfig;
+      this.restClientConfig &&
+      ('httpsAgent' in this.restClientConfig || 'httpAgent' in this.restClientConfig);
     const proxyAgents = hasCustomAgents ? {} : getProxyAgentForUrl(url, this.restClientConfig);
 
     return this.axiosInstance


### PR DESCRIPTION
fixed the issue in the request method in case if this.restClientConfig is not provided in the config

<img width="1647" height="304" alt="image" src="https://github.com/user-attachments/assets/eb853515-be2b-4e02-a77b-a293b96389ae" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential runtime error in REST client configuration handling that could occur when no custom agent settings are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->