### PR TITLE
EPMRPP-110786 || Fix error for empty restClientConfig while using HTTP retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### Fixed
+- Error for empty `restClientConfig` while using HTTP retries.
 
 ## [5.5.7] - 2025-12-09
 ### Changed

--- a/__tests__/rest.spec.js
+++ b/__tests__/rest.spec.js
@@ -134,6 +134,26 @@ describe('RestClient', () => {
       };
       expect(retryConfig.retryCondition(timeoutError)).toBe(true);
     });
+
+    it('handles undefined restClientConfig without crashing during retries', () => {
+      const client = new RestClient({
+        baseURL: options.baseURL,
+        headers: options.headers,
+        restClientConfig: undefined,
+      });
+
+      const retryConfig = client.getRetryConfig();
+      expect(retryConfig.retries).toBe(6);
+
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+      const onRetry = retryConfig.onRetry;
+      
+      expect(() => {
+        onRetry(1, { code: 'ECONNABORTED' }, { method: 'GET', url: 'http://test.com' });
+      }).not.toThrow();
+
+      consoleSpy.mockRestore();
+    });
   });
 
   describe('buildPath', () => {

--- a/lib/rest.js
+++ b/lib/rest.js
@@ -150,7 +150,7 @@ method: ${method}`,
   getRetryConfig() {
     const retryOption = this.restClientConfig?.retry;
     const onRetry = (retryCount, error, requestConfig) => {
-      if (this.restClientConfig.debug) {
+      if (this.restClientConfig?.debug) {
         console.log(`[retry #${retryCount}] ${requestConfig.method?.toUpperCase()} ${requestConfig.url} -> ${error.code || error.message}`);
       }
     };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an error that occurred when using HTTP retries with an empty or undefined configuration. The retry mechanism now properly handles these scenarios, allowing retries to function correctly regardless of configuration state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->